### PR TITLE
Make toolchain building under Linux

### DIFF
--- a/tools/gbdk_infinity.diff
+++ b/tools/gbdk_infinity.diff
@@ -1,6 +1,6 @@
-diff -ru SDK.orig/gbz80-gb/2-1-5/lib/crt0.s SDK/gbz80-gb/2-1-5/lib/crt0.s
---- SDK.orig/gbz80-gb/2-1-5/lib/crt0.s	1999-10-17 22:02:46.000000000 -0700
-+++ SDK/gbz80-gb/2-1-5/lib/crt0.s	2016-07-25 14:14:31.603316904 -0700
+diff -ru sdk.orig/gbz80-gb/2.1.5/lib/crt0.s sdk/gbz80-gb/2.1.5/lib/crt0.s
+--- sdk.orig/gbz80-gb/2.1.5/lib/crt0.s	1999-10-17 22:02:46.000000000 -0700
++++ sdk/gbz80-gb/2.1.5/lib/crt0.s	2016-07-25 14:14:31.603316904 -0700
 @@ -10,66 +10,99 @@
  	.org	0x00
  	RET			; Empty function (default for interrupts)
@@ -748,9 +748,9 @@ diff -ru SDK.orig/gbz80-gb/2-1-5/lib/crt0.s SDK/gbz80-gb/2-1-5/lib/crt0.s
  
  	.area	_HEAP
  _malloc_heap_start::
-diff -ru SDK.orig/gbz80-gb/2-1-5/lib/mul.s SDK/gbz80-gb/2-1-5/lib/mul.s
---- SDK.orig/gbz80-gb/2-1-5/lib/mul.s	1999-10-17 22:02:49.000000000 -0700
-+++ SDK/gbz80-gb/2-1-5/lib/mul.s	2016-07-25 14:14:31.775316898 -0700
+diff -ru sdk.orig/gbz80-gb/2.1.5/lib/mul.s sdk/gbz80-gb/2.1.5/lib/mul.s
+--- sdk.orig/gbz80-gb/2.1.5/lib/mul.s	1999-10-17 22:02:49.000000000 -0700
++++ sdk/gbz80-gb/2.1.5/lib/mul.s	2016-07-25 14:14:31.775316898 -0700
 @@ -1,13 +1,7 @@
 -	.include	"global.s"
 +   .include "global.s"

--- a/tools/toolchain/Makefile
+++ b/tools/toolchain/Makefile
@@ -1,3 +1,8 @@
+UNAME_S := $(shell uname -s)
+ifeq ($(UNAME_S),Linux)
+	LDLIBS = -lcurses
+endif
+
 all: ../../bin/afzconv ../../bin/fixgb ../../bin/gfx2h ../../bin/inspage ../../bin/itemconv ../../bin/j2w ../../bin/pagesize ../../bin/pagify ../../bin/post ../../bin/proctext ../../bin/gbr2bin
 
 enemy.o: enemy.c
@@ -19,7 +24,8 @@ enemy.o: enemy.c
 	gcc -Wall -o ../../bin/itemconv itemconv.c
 
 ../../bin/j2w: j2w.c
-	gcc -Wall -o ../../bin/j2w j2w.c
+	echo "$(LDLIBS)"
+	gcc -Wall $(LDLIBS) -o ../../bin/j2w j2w.c
 
 ../../bin/pagesize: pagesize.c
 	gcc -Wall -o ../../bin/pagesize pagesize.c

--- a/tools/toolchain/j2w.c
+++ b/tools/toolchain/j2w.c
@@ -23,6 +23,7 @@
 
 #if !defined(__MACH__) || !defined(__APPLE__)
 #include<malloc.h>
+#include<curses.h>
 #endif
 
 //#include<bios.h>


### PR DESCRIPTION
I've seen you're patching toolchain to allow it to build on macOS, so I've started patching it to make it working on Linux.

(second try because of unnecessary commit)

Changes:
- Added ncurses linking under Linux for j2w utility
- Slightly modified GBDK patch, so it can be directly used on GBDK toolchain (tested on `sdk-gbz80-gb-2.1.5-linux_glibc.tar.gz` package)
